### PR TITLE
Fix memory leaks with Combine subscriptions

### DIFF
--- a/final/MakeItSo/MakeItSo.xcodeproj/project.pbxproj
+++ b/final/MakeItSo/MakeItSo.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3584A215246D911000B41569 /* PublisherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3584A214246D911000B41569 /* PublisherExtension.swift */; };
+		3584A215246D911000B41569 /* Publisher+Assign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3584A214246D911000B41569 /* Publisher+Assign.swift */; };
 		60758A2524BA8CE6B4A6DED7 /* Pods_MakeItSo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7389934F4E83C47499E91BB4 /* Pods_MakeItSo.framework */; };
 		88169CC623C8A081009CFC9C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88169CC523C8A081009CFC9C /* AppDelegate.swift */; };
 		88169CC823C8A081009CFC9C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88169CC723C8A081009CFC9C /* SceneDelegate.swift */; };
@@ -30,7 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3584A214246D911000B41569 /* PublisherExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublisherExtension.swift; sourceTree = "<group>"; };
+		3584A214246D911000B41569 /* Publisher+Assign.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+Assign.swift"; sourceTree = "<group>"; };
 		6CA57FACA66B563CF5EFACEC /* Pods-MakeItSo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MakeItSo.release.xcconfig"; path = "Target Support Files/Pods-MakeItSo/Pods-MakeItSo.release.xcconfig"; sourceTree = "<group>"; };
 		7389934F4E83C47499E91BB4 /* Pods_MakeItSo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MakeItSo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88169CC223C8A081009CFC9C /* Make It So.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Make It So.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -175,7 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				88DF00C223FC46FE0007B71E /* EnvironmentKeys.swift */,
-				3584A214246D911000B41569 /* PublisherExtension.swift */,
+				3584A214246D911000B41569 /* Publisher+Assign.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -327,7 +327,7 @@
 				88169CCA23C8A081009CFC9C /* TaskListView.swift in Sources */,
 				88D22F8223CDDC73003C6D03 /* TaskRepository.swift in Sources */,
 				88EC1C1F23FD86B20045F6A8 /* SettingsView.swift in Sources */,
-				3584A215246D911000B41569 /* PublisherExtension.swift in Sources */,
+				3584A215246D911000B41569 /* Publisher+Assign.swift in Sources */,
 				88B508EF23FDD19E00AC508B /* SettingsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/final/MakeItSo/MakeItSo.xcodeproj/project.pbxproj
+++ b/final/MakeItSo/MakeItSo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3584A215246D911000B41569 /* PublisherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3584A214246D911000B41569 /* PublisherExtension.swift */; };
 		60758A2524BA8CE6B4A6DED7 /* Pods_MakeItSo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7389934F4E83C47499E91BB4 /* Pods_MakeItSo.framework */; };
 		88169CC623C8A081009CFC9C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88169CC523C8A081009CFC9C /* AppDelegate.swift */; };
 		88169CC823C8A081009CFC9C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88169CC723C8A081009CFC9C /* SceneDelegate.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3584A214246D911000B41569 /* PublisherExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublisherExtension.swift; sourceTree = "<group>"; };
 		6CA57FACA66B563CF5EFACEC /* Pods-MakeItSo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MakeItSo.release.xcconfig"; path = "Target Support Files/Pods-MakeItSo/Pods-MakeItSo.release.xcconfig"; sourceTree = "<group>"; };
 		7389934F4E83C47499E91BB4 /* Pods_MakeItSo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MakeItSo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88169CC223C8A081009CFC9C /* Make It So.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Make It So.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				88DF00C223FC46FE0007B71E /* EnvironmentKeys.swift */,
+				3584A214246D911000B41569 /* PublisherExtension.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -324,6 +327,7 @@
 				88169CCA23C8A081009CFC9C /* TaskListView.swift in Sources */,
 				88D22F8223CDDC73003C6D03 /* TaskRepository.swift in Sources */,
 				88EC1C1F23FD86B20045F6A8 /* SettingsView.swift in Sources */,
+				3584A215246D911000B41569 /* PublisherExtension.swift in Sources */,
 				88B508EF23FDD19E00AC508B /* SettingsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/final/MakeItSo/MakeItSo/Repositories/TaskRepository.swift
+++ b/final/MakeItSo/MakeItSo/Repositories/TaskRepository.swift
@@ -121,8 +121,8 @@ class FirestoreTaskRepository: BaseTaskRepository, TaskRepository, ObservableObj
     // (re)load data if user changes
     authenticationService.$user
       .receive(on: DispatchQueue.main)
-        .sink { [weak self] user in
-            self?.loadData()
+      .sink { [weak self] user in
+        self?.loadData()
       }
       .store(in: &cancellables)
   }

--- a/final/MakeItSo/MakeItSo/Repositories/TaskRepository.swift
+++ b/final/MakeItSo/MakeItSo/Repositories/TaskRepository.swift
@@ -121,8 +121,8 @@ class FirestoreTaskRepository: BaseTaskRepository, TaskRepository, ObservableObj
     // (re)load data if user changes
     authenticationService.$user
       .receive(on: DispatchQueue.main)
-      .sink { user in
-        self.loadData()
+        .sink { [weak self] user in
+            self?.loadData()
       }
       .store(in: &cancellables)
   }

--- a/final/MakeItSo/MakeItSo/Utilities/Publisher+Assign.swift
+++ b/final/MakeItSo/MakeItSo/Utilities/Publisher+Assign.swift
@@ -10,9 +10,9 @@ import Combine
 
 /// https://forums.swift.org/t/does-assign-to-produce-memory-leaks/29546/11
 extension Publisher where Failure == Never {
-    func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Output>, on root: Root) -> AnyCancellable {
-       sink { [weak root] in
-            root?[keyPath: keyPath] = $0
-        }
+  func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Output>, on root: Root) -> AnyCancellable {
+    sink { [weak root] in
+      root?[keyPath: keyPath] = $0
     }
+  }
 }

--- a/final/MakeItSo/MakeItSo/Utilities/Publisher+Assign.swift
+++ b/final/MakeItSo/MakeItSo/Utilities/Publisher+Assign.swift
@@ -1,5 +1,5 @@
 //
-//  PublisherExtension.swift
+//  Publisher+Assign.swift
 //  MakeItSo
 //
 //  Created by Jeremy Gale on 2020-05-14.

--- a/final/MakeItSo/MakeItSo/Utilities/PublisherExtension.swift
+++ b/final/MakeItSo/MakeItSo/Utilities/PublisherExtension.swift
@@ -1,0 +1,18 @@
+//
+//  PublisherExtension.swift
+//  MakeItSo
+//
+//  Created by Jeremy Gale on 2020-05-14.
+//  Copyright © 2020 Google LLC. All rights reserved.
+//
+
+import Combine
+
+/// https://forums.swift.org/t/does-assign-to-produce-memory-leaks/29546/11
+extension Publisher where Failure == Never {
+    func assign<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Output>, on root: Root) -> AnyCancellable {
+       sink { [weak root] in
+            root?[keyPath: keyPath] = $0
+        }
+    }
+}

--- a/final/MakeItSo/MakeItSo/ViewModels/TaskCellViewModel.swift
+++ b/final/MakeItSo/MakeItSo/ViewModels/TaskCellViewModel.swift
@@ -40,8 +40,8 @@ class TaskCellViewModel: ObservableObject, Identifiable  {
     $task
       .dropFirst()
       .debounce(for: 0.8, scheduler: RunLoop.main)
-      .sink { task in
-        self.taskRepository.updateTask(task)
+      .sink { [weak self] task in
+        self?.taskRepository.updateTask(task)
       }
       .store(in: &cancellables)
   }


### PR DESCRIPTION
I was experimenting with this awesome tutorial and realized the `TaskCellViewModel` was never getting deallocated.

I researched it and came across this helpful Swift form post: https://forums.swift.org/t/does-assign-to-produce-memory-leaks/29546/11

Adapted quote:
> Indeed there is a retain cycle with the sample code that uses assign:
>
> The TaskCellViewModel retains the AnyCancellable (1), which retains the Subscribers.Assign subscription (2), which retains the Bar (3) in order to be able to perform the assignment. Cycle completed: the TaskCellViewModel is never deinited.

I fixed this by:

1. Using `[weak self]` for the Combine subscriptions that use `sink`
2. Added a extension on Publisher that makes `assign` not retain the object, which was from the above forum post

If you prefer not overloading the `assign` name I'm happy to rename it `assignNoRetain` or something like that for clarity.

After this change, a `deinit()` on `TaskCellViewModel` does get regularly called. I should note that I still see leaks when running this new code in Instruments, but it's a little beyond me to understand why. 😞 