### PR TITLE
Update SceneDelegate.swift

### DIFF
--- a/final/MakeItSo/MakeItSo/App/SceneDelegate.swift
+++ b/final/MakeItSo/MakeItSo/App/SceneDelegate.swift
@@ -19,12 +19,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
 
-    // Create the SwiftUI view that provides the window contents.
-    let contentView = TaskListView()
-
     // Use a UIHostingController as window root view controller.
     if let windowScene = scene as? UIWindowScene {
         let window = UIWindow(windowScene: windowScene)
+
+        // Create the SwiftUI view that provides the window contents.
+        // Set the window EnvironmentKey to the current window for the contentView's environment.
+        let contentView = TaskListView().environment(\.window, window)
+
         window.rootViewController = UIHostingController(rootView: contentView)
         self.window = window
         window.makeKeyAndVisible()


### PR DESCRIPTION
Set the window EnvironmentKey to the window for the contentView's environment in the SceneDelegate. This is necessary for multiple window support.